### PR TITLE
Fix persona deletion cleanup bug

### DIFF
--- a/app/core/model/persona.py
+++ b/app/core/model/persona.py
@@ -120,6 +120,7 @@ class Persona:
                 connection.rollback()
             return False
         finally:
-            if connection is not None and connection.is_connected():
+            if cursor is not None:
                 cursor.close()
-                connection.close() 
+            if connection is not None and connection.is_connected():
+                connection.close()


### PR DESCRIPTION
## Summary
- fix cursor handling in `Persona.delete` so the cursor closes even if the DB connection has dropped

## Testing
- `python -m py_compile $(git ls-files '*.py')`